### PR TITLE
Fix documentation for must_keep_debug

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcModuleApi.java
@@ -868,7 +868,7 @@ public interface CcModuleApi<
         @Param(
             name = "must_keep_debug",
             doc =
-                "When set to True, bazel will expose 'strip_debug_symbols' variable, which is "
+                "When set to False, bazel will expose 'strip_debug_symbols' variable, which is "
                     + "usually used to use the linker to strip debug symbols from the output file.",
             named = true,
             positional = false,


### PR DESCRIPTION
The logic in the documentation was reversed.  Setting the flag to `False` (opposite of the default) exposes the `strip_debug_symbols` variable.

Fixes #14322